### PR TITLE
fix(CaptainsLogPlugin): Correct regex group index for filename extraction

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -500,7 +500,7 @@ export default class CaptainsLogPlugin extends Plugin {
 		let result: RegExpExecArray | null;
 		for (const reg of regex) {
 			while ((result = reg.exec(text)) !== null) {
-				filename = normalizePath(decodeURI(result[0])).trim();
+				filename = normalizePath(decodeURI(result[1])).trim();
 			}
 		}
 		if (filename === '') throw new Error('No file found in the text.');


### PR DESCRIPTION
running the transscribe on an obsidian md file with the content:

```
![[recording-2025-04-29-Afternoon-3.mp3]]
```
Fails with file not found.

This PR fixes this issue.